### PR TITLE
Hashing the filename, and formatting adjustments for paste.sh

### DIFF
--- a/pasted/paste.sh
+++ b/pasted/paste.sh
@@ -3,14 +3,15 @@ ulimit -c 0
 ulimit -f 1024
 ulimit -t 10
 ulimit -m 1024
-path=/home/paste
-file=$path"/out/out_"$REMOTE_HOST"_"$(date +%s )".html"
-cat $path"/pasted/"header > $file
+localpath=/home/paste
+outhash=$(sha256sum <<< "${REMOTE_HOST}_$(date +%s )" | cut -d' ' -f1)
+file="${localpath}/out/out_${outhash}.html"
+cat ${localpath}/pasted/header > $file
 echo http://graph.sanxiago.com/out/$(basename $file)
-  if read -t 0; 
-    then
-        cat | sed -s 's/</./g' >> $file 
-    else
-        echo "$*" | sed -s 's/</./g'  > $file
-    fi
-cat $path"/pasted/"footer >> $file
+if read -t 0;
+then
+    cat | sed -s 's/</./g' >> $file
+else
+    echo "$*" | sed -s 's/</./g' > $file
+fi
+cat ${localpath}/pasted/footer >> $file


### PR DESCRIPTION
Per some initial discussion on the email list, it might be best to obfuscate the IP address of the REMOTE_HOST, and to ensure uniqueness, adding the timestamp in the hash as well.

Also, took the liberty of reformatting with more better bashisms.
- $path changed to $localpath, to avoid overwriting $PATH environment variable
- $outhash variable added, taking the place of $REMOTE_HOST"_"$(date +%s ) in the output file name
- quotes removed from header and footer lines
- indentation aligned for if block
